### PR TITLE
Update README with "_seconds" suffix on delay, interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,15 +54,15 @@ finds on the volumes which it is recycling.
 
 ## Role Variables
 
-| Name                                  | Default value                                  | Description                                                          |
-|---------------------------------------|------------------------------------------------|----------------------------------------------------------------------|
-| appuio_gluster_recycler_repo          | https://github.com/appuio/gluster-recycler.git | Source repository to build the Gluster recycler from                 |
-| appuio_gluster_recycler_repo_rev      | master                                         | Version of the Gluster recycler to build, i.e. Git ref of repo above |
-| appuio_gluster_recycler_namespace     | appuio-infra                                   | Namespace to install Gluster recycler into                           |
-| appuio_gluster_recycler_gluster_hosts | None (required)                                | Semi-colon separated list of gluster hosts                           |
-| appuio_gluster_recycler_interval      | 300                                            | Time in seconds to wait between recycler runs                        |
-| appuio_gluster_recycler_delay         | 0                                              | Time in seconds to wait before recycling a volume after it failed    |
-| appuio_gluster_recycler_timezone      | *appuio_container_timezone*, UTC               | Timezone of the container                                            |
+| Name                                     | Default value                                  | Description                                                          |
+|------------------------------------------|------------------------------------------------|----------------------------------------------------------------------|
+| appuio_gluster_recycler_repo             | https://github.com/appuio/gluster-recycler.git | Source repository to build the Gluster recycler from                 |
+| appuio_gluster_recycler_repo_rev         | master                                         | Version of the Gluster recycler to build, i.e. Git ref of repo above |
+| appuio_gluster_recycler_namespace        | appuio-infra                                   | Namespace to install Gluster recycler into                           |
+| appuio_gluster_recycler_gluster_hosts    | None (required)                                | Semi-colon separated list of gluster hosts                           |
+| appuio_gluster_recycler_interval_seconds | 300                                            | Time in seconds to wait between recycler runs                        |
+| appuio_gluster_recycler_delay_seconds    | 0                                              | Time in seconds to wait before recycling a volume after it failed    |
+| appuio_gluster_recycler_timezone         | *appuio_container_timezone*, UTC               | Timezone of the container                                            |
 
 
 ## Dependencies


### PR DESCRIPTION
The variables for delay and interval have been given a suffix of
"_seconds" in commit 45ae395, but the README file didn't reflect that.