### PR TITLE
Bump required version of ansible-module-openshift

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,4 +13,4 @@ galaxy_info:
   - cloud
 dependencies:
 - src: git+https://github.com/appuio/ansible-module-openshift.git
-  version: v1.2.1
+  version: v1.4.2


### PR DESCRIPTION
Version 1.4.2 of ansible-module-openshift fixes an annoying issue
whereby a newly created project would be selected in the client
configuration.