### PR TITLE
Reset owner and permissions on recycling

### DIFF
--- a/recycler.sh
+++ b/recycler.sh
@@ -168,6 +168,13 @@ clear_volume() {
     return 1
   fi
 
+  # reset owner to root
+  chown -R -c root:root "$path"
+  if [[ "$?" != 0 ]]; then
+    echo "ERROR: We could not reset the owner to root for this Volume!"
+    return 1
+  fi
+
   return 0
 }
 

--- a/recycler.sh
+++ b/recycler.sh
@@ -175,6 +175,13 @@ clear_volume() {
     return 1
   fi
 
+  # reset permissions
+  chmod -R -c 2775 "$path"
+  if [[ "$?" != 0 ]]; then
+    echo "ERROR: We could not reset the permissions for this Volume!"
+    return 1
+  fi
+
   return 0
 }
 


### PR DESCRIPTION
If a pod changed the owner of the volume, the recycler needs to reset the owner to root:root.