### PR TITLE
Set revisionHistoryLimit in deployment config

### DIFF
--- a/files/recycler-template.yml
+++ b/files/recycler-template.yml
@@ -134,6 +134,7 @@ objects:
     name: gluster-recycler
   spec:
     replicas: 1
+    revisionHistoryLimit: 2
     selector:
       name: gluster-recycler
     strategy:


### PR DESCRIPTION
By default deployment controllers retain all revisions of a deployment
which in combination with a quota limit on replication controllers will
lead to deployment delays or failures.