### PR TITLE
Try to remove the `.trashcan` directory

### DIFF
--- a/recycler.sh
+++ b/recycler.sh
@@ -168,6 +168,9 @@ clear_volume() {
     return 1
   fi
 
+  # try to remove the trashcan but ignore errors if it fails
+  rm -rf "${path}/.trashcan" || :
+
   # reset owner to root
   chown -R -c root:root "$path"
   if [[ "$?" != 0 ]]; then


### PR DESCRIPTION
We disable the trash translators some time ago, but many volumes still have their `.trashcan` directory. This leads to problems because it will show up when you mount the volume. MySQL for example thinks it is a database and tries to open the ".trashcan" DB (and fails)

With this change, the recycler tries to remove `.trashcan` directory, but does not complain if it fails.