### PR TITLE
Support externally-built image, convert to OpenShift cronjob

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7
+FROM docker.io/library/centos:7
 
 RUN \
   set -e && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN \
   rpm -V $INSTALL_PKGS && \
   yum clean all
 
-ENV TINI_VERSION v0.16.1
+ENV TINI_VERSION v0.18.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini.asc /tini.asc
 RUN \

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ finds on the volumes which it is recycling.
 | appuio_gluster_recycler_repo             | https://github.com/appuio/gluster-recycler.git | Source repository to build the Gluster recycler from                 |
 | appuio_gluster_recycler_repo_rev         | master                                         | Version of the Gluster recycler to build, i.e. Git ref of repo above |
 | appuio_gluster_recycler_namespace        | appuio-infra                                   | Namespace to install Gluster recycler into                           |
+| appuio_gluster_recycler_image            | None                                           | Image for recycler, uses image built on cluster by default           |
 | appuio_gluster_recycler_gluster_hosts    | None (required)                                | Semi-colon separated list of gluster hosts                           |
 | appuio_gluster_recycler_interval_seconds | 300                                            | Time in seconds to wait between recycler runs                        |
 | appuio_gluster_recycler_delay_seconds    | 0                                              | Time in seconds to wait before recycling a volume after it failed    |

--- a/README.md
+++ b/README.md
@@ -3,15 +3,15 @@
 This repository contains an Ansible role for automatic installation of the
 Gluster recycler, a program written by David McCormick.
 
-At present there is no recycle plugin implemented for GlusterFS persistent
-volumes in Openshift. This is inconvenient--despite plans to write a fully automated
-end-to-end provisioning plugin what do we do in the meantime to keep our
-OpenShift installations with available storage?
+As of OpenShift 3.9 there is no recycle plugin implemented for GlusterFS
+persistent volumes. This is inconvenient--despite plans to write a fully
+automated end-to-end provisioning plugin what do we do in the meantime to keep
+our OpenShift installations with available storage?
 
 The issue is that whenever a persistentVolumeClaim is created and then removed
 it again rather than freeing up the storage, the volume goes into a failed
-state instead with a message "no volume plugin matched", presumably to protect
-from giving the volume to someone else with files left on it.
+state instead with a message "no volume plugin matched" to protect from giving
+the volume to someone else with data left on it.
 
 The Gluster recycler is an interim work-around for while the offical gluster
 recycler plugin remains unavailable.
@@ -47,9 +47,8 @@ finds on the volumes which it is recycling.
 
 ## Requirements
 
-* OpenShift Enterprise 3.2
-* OpenShift Container Platform 3.3 or later
-* OpenShift Origin M5 1.3 or later
+* OpenShift Container Platform 3.5 or later
+* OpenShift Origin 3.5 or later
 
 
 ## Role Variables

--- a/README.md
+++ b/README.md
@@ -47,22 +47,22 @@ finds on the volumes which it is recycling.
 
 ## Requirements
 
-* OpenShift Container Platform 3.5 or later
-* OpenShift Origin 3.5 or later
+* OpenShift Container Platform 3.9 or later
+* OpenShift Origin 3.9 or later
 
 
 ## Role Variables
 
-| Name                                     | Default value                                  | Description                                                          |
-|------------------------------------------|------------------------------------------------|----------------------------------------------------------------------|
-| appuio_gluster_recycler_repo             | https://github.com/appuio/gluster-recycler.git | Source repository to build the Gluster recycler from                 |
-| appuio_gluster_recycler_repo_rev         | master                                         | Version of the Gluster recycler to build, i.e. Git ref of repo above |
-| appuio_gluster_recycler_namespace        | appuio-infra                                   | Namespace to install Gluster recycler into                           |
-| appuio_gluster_recycler_image            | None                                           | Image for recycler, uses image built on cluster by default           |
-| appuio_gluster_recycler_gluster_hosts    | None (required)                                | Semi-colon separated list of gluster hosts                           |
-| appuio_gluster_recycler_interval_seconds | 300                                            | Time in seconds to wait between recycler runs                        |
-| appuio_gluster_recycler_delay_seconds    | 0                                              | Time in seconds to wait before recycling a volume after it failed    |
-| appuio_gluster_recycler_timezone         | *appuio_container_timezone*, UTC               | Timezone of the container                                            |
+| Name                                  | Default value                                  | Description                                                          |
+|---------------------------------------|------------------------------------------------|----------------------------------------------------------------------|
+| appuio_gluster_recycler_repo          | https://github.com/appuio/gluster-recycler.git | Source repository to build the Gluster recycler from                 |
+| appuio_gluster_recycler_repo_rev      | master                                         | Version of the Gluster recycler to build, i.e. Git ref of repo above |
+| appuio_gluster_recycler_namespace     | appuio-infra                                   | Namespace to install Gluster recycler into                           |
+| appuio_gluster_recycler_image         | None                                           | Image for recycler, uses image built on cluster by default           |
+| appuio_gluster_recycler_gluster_hosts | None (required)                                | Semi-colon separated list of gluster hosts                           |
+| appuio_gluster_recycler_schedule      | \*/5 \* \* \* \*                               | Execution schedule in cron format                                    |
+| appuio_gluster_recycler_delay_seconds | 0                                              | Time in seconds to wait before recycling a volume after it failed    |
+| appuio_gluster_recycler_timezone      | *appuio_container_timezone*, UTC               | Timezone of the container                                            |
 
 
 ## Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@ appuio_gluster_recycler_namespace: appuio-infra
 appuio_gluster_recycler_repo: https://github.com/appuio/gluster-recycler.git
 appuio_gluster_recycler_repo_rev: master
 appuio_gluster_recycler_base_image: "{{ ((deployment_type | default(openshift_deployment_type)) == 'origin') | ternary('docker.io/library/centos:7', 'registry.access.redhat.com/rhel7') }}"
+appuio_gluster_recycler_image: null
 appuio_gluster_recycler_interval_seconds: 300
 appuio_gluster_recycler_delay_seconds: 0
 appuio_gluster_recycler_timezone: "{{ appuio_container_timezone | default('UTC') }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,6 @@ appuio_gluster_recycler_repo: https://github.com/appuio/gluster-recycler.git
 appuio_gluster_recycler_repo_rev: master
 appuio_gluster_recycler_base_image: "{{ ((deployment_type | default(openshift_deployment_type)) == 'origin') | ternary('docker.io/library/centos:7', 'registry.access.redhat.com/rhel7') }}"
 appuio_gluster_recycler_image: null
-appuio_gluster_recycler_interval_seconds: 300
+appuio_gluster_recycler_schedule: "*/5 * * * *"
 appuio_gluster_recycler_delay_seconds: 0
 appuio_gluster_recycler_timezone: "{{ appuio_container_timezone | default('UTC') }}"

--- a/files/recycler-build.yml
+++ b/files/recycler-build.yml
@@ -1,0 +1,71 @@
+---
+kind: Template
+apiVersion: v1
+metadata:
+  annotations:
+    description: "Build setup for GlusterFS persistent volume recycler"
+    version: '1.0.0'
+  name: setup-recycler
+labels:
+  template: "gluster-recycler"
+parameters:
+- description: Base image for recycler, registry.access.redhat.com/rhel7 or docker.io/library/centos:7, defaults to the former
+  name: BASE_IMAGE
+  required: true
+  value: registry.access.redhat.com/rhel7
+- description: 'Source Repo for recycler'
+  name: SOURCE_REPO
+  required: true
+  value: "https://github.com/appuio/gluster-recycler.git"
+- description: 'Gluster recycler version, i.e. git ref of the specified repository'
+  name: SOURCE_REF
+  value: master
+  required: true
+objects:
+
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: gluster-recycler-base
+  spec:
+    tags:
+      - name: latest
+        from:
+          kind: DockerImage
+          name: ${BASE_IMAGE}
+        importPolicy:
+          scheduled: true
+
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: gluster-recycler
+
+- apiVersion: v1
+  kind: BuildConfig
+  metadata:
+    creationTimestamp: null
+    name: gluster-recycler
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: gluster-recycler:latest
+    postCommit: {}
+    resources: {}
+    source:
+      git:
+        uri: ${SOURCE_REPO}
+        ref: ${SOURCE_REF}
+      secrets: []
+      type: Git
+    strategy:
+      type: Docker
+      dockerStrategy:
+        from:
+          kind: ImageStreamTag
+          name: gluster-recycler-base:latest
+    triggers:
+    - type: ConfigChange
+    - imageChange: {}
+      type: ImageChange

--- a/files/recycler-external.yml
+++ b/files/recycler-external.yml
@@ -1,0 +1,21 @@
+---
+kind: Template
+apiVersion: v1
+parameters:
+- description: 'Docker image reference for recycler image'
+  name: IMAGE
+  required: true
+objects:
+
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: gluster-recycler-external
+  spec:
+    tags:
+      - name: latest
+        from:
+          kind: DockerImage
+          name: ${IMAGE}
+        importPolicy:
+          scheduled: true

--- a/files/recycler-template.yml
+++ b/files/recycler-template.yml
@@ -120,8 +120,6 @@ objects:
               - name: TZ
                 value: ${TIMEZONE}
               args:
-                - "bash"
-                - "-c"
                 - "/recycler.sh"
               securityContext:
                 privileged: true

--- a/files/recycler-template.yml
+++ b/files/recycler-template.yml
@@ -3,7 +3,7 @@ kind: Template
 apiVersion: v1
 metadata:
   annotations:
-    description: "Setup for glusterfs persistent volume recycler.  Creates all the required objects and deploys the pod."
+    description: Setup for GlusterFS persistent volume recycler
     version: '1.0.0'
   name: setup-recycler
 labels:
@@ -27,43 +27,17 @@ parameters:
   name: DEBUG
   required: false
   value: "false"
-- description: Base image for recycler, registry.access.redhat.com/rhel7 or docker.io/library/centos:7, defaults to the former
-  name: BASE_IMAGE
-  required: true
-  value: registry.access.redhat.com/rhel7
-- description: 'Source Repo for recycler'
-  name: SOURCE_REPO
-  required: true
-  value: "https://github.com/appuio/gluster-recycler.git"
-- description: 'Gluster recycler version, i.e. git ref of the specified repository'
-  name: SOURCE_REF
-  value: master
-  required: true
 - description: 'Timezone (TZ) of the container, see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones for a list'
   name: TIMEZONE
   value: UTC
   required: true
 objects:
-- apiVersion: v1
-  kind: ImageStream
-  metadata:
-    name: gluster-recycler-base
-  spec:
-    tags:
-      - name: latest
-        from:
-          kind: DockerImage
-          name: ${BASE_IMAGE}
-        importPolicy:
-          scheduled: true
-- apiVersion: v1
-  kind: ImageStream
-  metadata:
-    name: gluster-recycler
+
 - apiVersion: v1
   kind: ServiceAccount
   metadata:
     name: gluster-recycler
+
 - kind: ClusterRole
   apiVersion: v1
   metadata:
@@ -81,6 +55,7 @@ objects:
     apiGroups:
     resources:
     - persistentvolumes
+
 - apiVersion: v1
   groupNames: null
   kind: ClusterRoleBinding
@@ -94,36 +69,7 @@ objects:
     namespace: ${NAMESPACE}
   userNames:
   - system:serviceaccount:${NAMESPACE}:gluster-recycler
-- apiVersion: v1
-  kind: BuildConfig
-  metadata:
-    creationTimestamp: null
-    labels:
-      app: gluster-recycler
-    name: gluster-recycler
-  spec:
-    output:
-      to:
-        kind: ImageStreamTag
-        name: gluster-recycler:latest
-    postCommit: {}
-    resources: {}
-    source:
-      git:
-        uri: ${SOURCE_REPO}
-        ref: ${SOURCE_REF}
-      secrets: []
-      type: Git
-    strategy:
-      type: Docker
-      dockerStrategy:
-        from:
-          kind: ImageStreamTag
-          name: gluster-recycler-base:latest
-    triggers:
-    - type: ConfigChange
-    - imageChange: {}
-      type: ImageChange
+
 - apiVersion: v1
   kind: DeploymentConfig
   metadata:

--- a/files/recycler-template.yml
+++ b/files/recycler-template.yml
@@ -27,7 +27,7 @@ parameters:
   name: DEBUG
   required: false
   value: "false"
-- description: Base image for recycler, registry.access.redhat.com/rhel7 or centos:7, defaults to the former
+- description: Base image for recycler, registry.access.redhat.com/rhel7 or docker.io/library/centos:7, defaults to the former
   name: BASE_IMAGE
   required: true
   value: registry.access.redhat.com/rhel7

--- a/files/recycler-template.yml
+++ b/files/recycler-template.yml
@@ -15,10 +15,10 @@ parameters:
 - description: 'A semi-colon ";" separated list of glusterfs hosts that make up your glusterfs cluster (only one cluster supported).'
   name: GLUSTER_HOSTS
   required: true
-- description: 'Interval in seconds between recycler runs (defaults to every 5 minutes)'
-  name: INTERVAL
+- description: 'Cronjob execution schedule in cron format'
+  name: SCHEDULE
   required: false
-  value: "300"
+  value: "*/5 * * * *"
 - description: 'Delay in seconds before a volume is recycled after it failed (defaults to no delay)'
   name: DELAY
   required: false
@@ -74,54 +74,57 @@ objects:
   userNames:
   - system:serviceaccount:${NAMESPACE}:gluster-recycler
 
-- apiVersion: v1
-  kind: DeploymentConfig
+- apiVersion: batch/v1beta1
+  kind: CronJob
   metadata:
-    labels:
     name: gluster-recycler
+    annotations:
+      # https://docs.openshift.com/container-platform/3.9/dev_guide/managing_images.html#image-stream-kubernetes-resources
+      image.openshift.io/triggers: |-
+        [{
+          "from": {
+            "kind": "ImageStreamTag",
+            "name": "${IMAGE_STREAM_NAME}:latest"
+          },
+          "fieldPath": "spec.jobTemplate.spec.template.spec.containers[?(@.name==\"gluster-recycler\")].image"
+        }]
   spec:
-    replicas: 1
-    revisionHistoryLimit: 2
-    selector:
-      name: gluster-recycler
-    strategy:
-      type: Recreate
-    template:
-      metadata:
-        labels:
-          name: gluster-recycler
-        name: gluster-recycler
+    schedule: ${SCHEDULE}
+    failedJobsHistoryLimit: 10
+    successfulJobsHistoryLimit: 10
+    concurrencyPolicy: Forbid
+    jobTemplate:
       spec:
-        containers:
-        - name: gluster-recycler
-          image: gluster-recycler
-          imagePullPolicy: Always
-          env:
-          - name: INTERVAL
-            value: ${INTERVAL}
-          - name: DELAY
-            value: ${DELAY}
-          - name: CLUSTER
-            value: ${GLUSTER_HOSTS}
-          - name: DEBUG
-            value: ${DEBUG}
-          - name: TZ
-            value: ${TIMEZONE}
-          args:
-            - "bash"
-            - "-c"
-            - "/recycler.sh"
-          securityContext:
-            privileged: true
-        restartPolicy: Always
-        serviceAccountName: gluster-recycler
-    triggers:
-    - type: ConfigChange
-    - type: ImageChange
-      imageChangeParams:
-        automatic: true
-        from:
-          kind: ImageStream
-          name: ${IMAGE_STREAM_NAME}
-        containerNames:
-        - gluster-recycler
+        activeDeadlineSeconds: 7200
+        completions: 1
+        # Don't retry failed executions
+        backoffLimit: 0
+        template:
+          metadata:
+            labels:
+              name: gluster-recycler
+          spec:
+            containers:
+            - name: gluster-recycler
+              image: " "
+              imagePullPolicy: IfNotPresent
+              env:
+              - name: ONESHOT
+                value: "true"
+              - name: DELAY
+                value: ${DELAY}
+              - name: CLUSTER
+                value: ${GLUSTER_HOSTS}
+              - name: DEBUG
+                value: ${DEBUG}
+              - name: TZ
+                value: ${TIMEZONE}
+              args:
+                - "bash"
+                - "-c"
+                - "/recycler.sh"
+              securityContext:
+                privileged: true
+            serviceAccountName: gluster-recycler
+            # https://github.com/kubernetes/kubernetes/issues/54870
+            restartPolicy: Never

--- a/files/recycler-template.yml
+++ b/files/recycler-template.yml
@@ -31,6 +31,10 @@ parameters:
   name: TIMEZONE
   value: UTC
   required: true
+- description: 'Name of image stream for recycler container'
+  name: IMAGE_STREAM_NAME
+  value: gluster-recycler
+  required: true
 objects:
 
 - apiVersion: v1
@@ -118,6 +122,6 @@ objects:
         automatic: true
         from:
           kind: ImageStream
-          name: gluster-recycler
+          name: ${IMAGE_STREAM_NAME}
         containerNames:
         - gluster-recycler

--- a/files/recycler-template.yml
+++ b/files/recycler-template.yml
@@ -49,9 +49,6 @@ objects:
   metadata:
     name: gluster-recycler-base
   spec:
-    importPolicy:
-      scheduled:
-        true
     tags:
       - name: latest
         from:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Role installing Gluster recycler
   company: Puzzle ITC and VSHN
   license: Apache License, Version 2.0
-  min_ansible_version: 2.2
+  min_ansible_version: 2.4
   platforms:
   - name: EL
     versions:

--- a/recycler.sh
+++ b/recycler.sh
@@ -28,6 +28,7 @@
 # INTERVAL - the pause between recyle runs in seconds (default 5 minutes)
 # DELAY - number of seconds to delay recycling after pv has first been seen in failed state
 # DEBUG - set to 'true' to enable detailed logging.
+# ONESHOT - set to 'true' to exit after one iteration
 
 ANNOTATION_FAILED_AT=appuio.ch/failed-at
 
@@ -36,6 +37,10 @@ if [[ ! $DELAY =~ [0-9]+ ]]; then
   DELAY="0"
   echo "DELAY is not a number, ignoring!" >&2
 fi
+
+is_oneshot() {
+  [[ "$ONESHOT" == true ]]
+}
 
 is_debug() {
   [[ "$DEBUG" == true ]]
@@ -369,41 +374,41 @@ recycle_volume() {
   fi
 }
 
-# start the loop
-while true
-do
-
+while true; do
   # Get a list of physical volumes and their status
   is_debug && echo "Getting a list of persistentvolumes..."
   vol_list=$(api_call GET /api/v1/persistentvolumes)
-  if [ "$?" -eq "0" ]; then
-    is_debug && echo "result of api call: $vol_list"
-
-    echo "$vol_list" | \
-      jq -r '.items | map(select(.status.phase == "Failed"))' \
-      > "${tmpdir}/failed.json"
-
-    num_vols=$(jq -r length < "${tmpdir}/failed.json")
-
-    echo "$(date -Is): ${num_vols} failed volumes found"
-
-    # interate over the persistent volumes a volume at a time
-    for i in $(seq 0 $((num_vols - 1))); do
-      jq -r --argjson idx "$i" '.[$idx]' \
-        < "${tmpdir}/failed.json" \
-        > "${tmpdir}/volume.json"
-
-      recycle_volume "${tmpdir}/volume.json"
-    done
-    echo "Finished recycle run"
-
-  else
+  if [ "$?" -ne "0" ]; then
     echo "ERROR! Could not get list of volumes from the API!"
     sleep 60
     exit 1
   fi
 
-  # wait for next run through
+  is_debug && echo "result of api call: $vol_list"
+
+  echo "$vol_list" | \
+    jq -r '.items | map(select(.status.phase == "Failed"))' \
+    > "${tmpdir}/failed.json"
+
+  num_vols=$(jq -r length < "${tmpdir}/failed.json")
+
+  echo "$(date -Is): ${num_vols} failed volumes found"
+
+  # interate over the persistent volumes a volume at a time
+  for i in $(seq 0 $((num_vols - 1))); do
+    jq -r --argjson idx "$i" '.[$idx]' \
+      < "${tmpdir}/failed.json" \
+      > "${tmpdir}/volume.json"
+
+    recycle_volume "${tmpdir}/volume.json"
+  done
+  echo "Finished recycle run"
+
+  if is_oneshot; then
+    break
+  fi
+
+  # Wait for next iteration
   sleep $INTERVAL
 
 done

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,11 +16,41 @@
   register: tempdir
   changed_when: False
 
-- block:
+- vars:
+    r_image: "{{ appuio_gluster_recycler_image | default(none) }}"
+    r_delete_objects_global: []
+    r_required_objects_build:
+      - ImageStream/gluster-recycler
+      - ImageStream/gluster-recycler-base
+      - BuildConfig/gluster-recycler
+    r_required_objects_external:
+      - ImageStream/gluster-recycler-external
+    r_delete_objects: >-
+      {{
+      r_delete_objects_global +
+      r_required_objects_build +
+      r_required_objects_external
+      }}
+    r_configs:
+      - template: recycler-build.yml
+        args:
+          BASE_IMAGE: "{{ appuio_gluster_recycler_base_image }}"
+          SOURCE_REPO: "{{ appuio_gluster_recycler_repo }}"
+          SOURCE_REF: "{{ appuio_gluster_recycler_repo_rev }}"
+        image_stream_name: gluster-recycler
+        required_objects: "{{ r_required_objects_build }}"
+      - template: recycler-external.yml
+        args:
+          IMAGE: "{{ r_image }}"
+        image_stream_name: gluster-recycler-external
+        required_objects: "{{ r_required_objects_external }}"
+    r_selected: "{{ r_configs[r_image | ternary(1, 0)] }}"
+  block:
     - name: Copy template
       with_list:
         - recycler-build.yml
         - recycler-template.yml
+        - recycler-external.yml
       copy:
         src: "{{ role_path }}/files/{{ item }}"
         dest: "{{ tempdir.path }}/{{ item }}"
@@ -29,12 +59,9 @@
     - name: Instantiate base recycler template
       openshift_resource:
         namespace: "{{ appuio_gluster_recycler_namespace }}"
-        template: "{{ tempdir.path }}/recycler-build.yml"
+        template: "{{ tempdir.path }}/{{ r_selected.template }}"
         app_name: gluster-recycler
-        arguments:
-          BASE_IMAGE: "{{ appuio_gluster_recycler_base_image }}"
-          SOURCE_REPO: "{{ appuio_gluster_recycler_repo }}"
-          SOURCE_REF: "{{ appuio_gluster_recycler_repo_rev }}"
+        arguments: "{{ r_selected.args }}"
 
     - name: Instantiate main recycler template
       openshift_resource:
@@ -47,6 +74,16 @@
           INTERVAL: "{{ appuio_gluster_recycler_interval_seconds | string }}"
           DELAY: "{{ appuio_gluster_recycler_delay_seconds | string }}"
           TIMEZONE: "{{ appuio_gluster_recycler_timezone }}"
+          IMAGE_STREAM_NAME: "{{ r_selected.image_stream_name }}"
+
+    - name: Remove recycler objects
+      vars:
+        r_obj: "{{ r_delete_objects | difference(r_selected.required_objects) }}"
+      when: r_obj
+      command: >-
+        oc -n {{ appuio_gluster_recycler_namespace | quote }}
+        delete --ignore-not-found
+        {{ r_obj | map("quote") | join(" ") }}
   always:
     - name: Delete temp directory
       file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,36 +11,35 @@
       - "system:serviceaccount:{{ appuio_gluster_recycler_namespace }}:gluster-recycler"
 
 - name: Create temp directory for doing work in
-  command: mktemp -d /tmp/ansible-gluster-recycler-XXXXXXXX
-  register: mktemp
+  tempfile:
+    state: directory
+  register: tempdir
   changed_when: False
 
-- set_fact:
-    tempdir: "{{ mktemp.stdout }}"
+- block:
+    - name: Copy template
+      copy:
+        src: "{{ role_path }}/files/recycler-template.yml"
+        dest: "{{ tempdir.path }}/template.yml"
+      changed_when: False
 
-- name: Copy template
-  copy:
-    src: "{{ role_path }}/files/recycler-template.yml"
-    dest: "{{ tempdir }}/template.yml"
-  changed_when: False
-
-- name: Instantiate recycler template
-  openshift_resource:
-    namespace: "{{ appuio_gluster_recycler_namespace }}"
-    template: "{{ tempdir }}/template.yml"
-    app_name: gluster-recycler
-    arguments:
-      NAMESPACE: "{{ appuio_gluster_recycler_namespace }}"
-      GLUSTER_HOSTS: "{{ appuio_gluster_recycler_gluster_hosts | mandatory }}"
-      BASE_IMAGE: "{{ appuio_gluster_recycler_base_image }}"
-      SOURCE_REPO: "{{ appuio_gluster_recycler_repo }}"
-      SOURCE_REF: "{{ appuio_gluster_recycler_repo_rev }}"
-      INTERVAL: "{{ appuio_gluster_recycler_interval_seconds | string }}"
-      DELAY: "{{ appuio_gluster_recycler_delay_seconds | string }}"
-      TIMEZONE: "{{ appuio_gluster_recycler_timezone }}"
-
-- name: Delete temp directory
-  file:
-    name: "{{ tempdir }}"
-    state: absent
-  changed_when: False
+    - name: Instantiate recycler template
+      openshift_resource:
+        namespace: "{{ appuio_gluster_recycler_namespace }}"
+        template: "{{ tempdir.path }}/template.yml"
+        app_name: gluster-recycler
+        arguments:
+          NAMESPACE: "{{ appuio_gluster_recycler_namespace }}"
+          GLUSTER_HOSTS: "{{ appuio_gluster_recycler_gluster_hosts | mandatory }}"
+          BASE_IMAGE: "{{ appuio_gluster_recycler_base_image }}"
+          SOURCE_REPO: "{{ appuio_gluster_recycler_repo }}"
+          SOURCE_REF: "{{ appuio_gluster_recycler_repo_rev }}"
+          INTERVAL: "{{ appuio_gluster_recycler_interval_seconds | string }}"
+          DELAY: "{{ appuio_gluster_recycler_delay_seconds | string }}"
+          TIMEZONE: "{{ appuio_gluster_recycler_timezone }}"
+  always:
+    - name: Delete temp directory
+      file:
+        name: "{{ tempdir.path }}"
+        state: absent
+      changed_when: False

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,22 +18,32 @@
 
 - block:
     - name: Copy template
+      with_list:
+        - recycler-build.yml
+        - recycler-template.yml
       copy:
-        src: "{{ role_path }}/files/recycler-template.yml"
-        dest: "{{ tempdir.path }}/template.yml"
+        src: "{{ role_path }}/files/{{ item }}"
+        dest: "{{ tempdir.path }}/{{ item }}"
       changed_when: False
 
-    - name: Instantiate recycler template
+    - name: Instantiate base recycler template
       openshift_resource:
         namespace: "{{ appuio_gluster_recycler_namespace }}"
-        template: "{{ tempdir.path }}/template.yml"
+        template: "{{ tempdir.path }}/recycler-build.yml"
+        app_name: gluster-recycler
+        arguments:
+          BASE_IMAGE: "{{ appuio_gluster_recycler_base_image }}"
+          SOURCE_REPO: "{{ appuio_gluster_recycler_repo }}"
+          SOURCE_REF: "{{ appuio_gluster_recycler_repo_rev }}"
+
+    - name: Instantiate main recycler template
+      openshift_resource:
+        namespace: "{{ appuio_gluster_recycler_namespace }}"
+        template: "{{ tempdir.path }}/recycler-template.yml"
         app_name: gluster-recycler
         arguments:
           NAMESPACE: "{{ appuio_gluster_recycler_namespace }}"
           GLUSTER_HOSTS: "{{ appuio_gluster_recycler_gluster_hosts | mandatory }}"
-          BASE_IMAGE: "{{ appuio_gluster_recycler_base_image }}"
-          SOURCE_REPO: "{{ appuio_gluster_recycler_repo }}"
-          SOURCE_REF: "{{ appuio_gluster_recycler_repo_rev }}"
           INTERVAL: "{{ appuio_gluster_recycler_interval_seconds | string }}"
           DELAY: "{{ appuio_gluster_recycler_delay_seconds | string }}"
           TIMEZONE: "{{ appuio_gluster_recycler_timezone }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,7 +18,8 @@
 
 - vars:
     r_image: "{{ appuio_gluster_recycler_image | default(none) }}"
-    r_delete_objects_global: []
+    r_delete_objects_global:
+      - DeploymentConfig/gluster-recycler
     r_required_objects_build:
       - ImageStream/gluster-recycler
       - ImageStream/gluster-recycler-base
@@ -71,7 +72,7 @@
         arguments:
           NAMESPACE: "{{ appuio_gluster_recycler_namespace }}"
           GLUSTER_HOSTS: "{{ appuio_gluster_recycler_gluster_hosts | mandatory }}"
-          INTERVAL: "{{ appuio_gluster_recycler_interval_seconds | string }}"
+          SCHEDULE: "{{ appuio_gluster_recycler_schedule | string }}"
           DELAY: "{{ appuio_gluster_recycler_delay_seconds | string }}"
           TIMEZONE: "{{ appuio_gluster_recycler_timezone }}"
           IMAGE_STREAM_NAME: "{{ r_selected.image_stream_name }}"


### PR DESCRIPTION
There are environments which don't support Docker builds on the cluster. To use the Gluster recycler on such environments it's necessary to build it elsewhere. With this change series it becomes possible to set `appuio_gluster_recycler_image`, in which case the build configuration is not set up.

For easier operations the recycler is amended with a configuration environment variable to terminate after a single iteration of all failed volumes (`ONESHOT=true`). With that change it's possible to use OpenShift cron jobs to schedule regular runs of the recycler than having a pod run continously. With this change the OpenShift version dependency changes to version 3.9 (required for `backoffLimit` in job objects).