### PR TITLE
Update to Gluster 4.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,11 @@ RUN \
   if ( . /etc/os-release && [ "$NAME" = rhel ] ); then \
     extrapkg=http://mirror.centos.org/centos/7/extras/x86_64/Packages && \
     PRE_INSTALL_PKG="${PRE_INSTALL_PKG} \
-      ${extrapkg}/centos-release-storage-common-1-2.el7.centos.noarch.rpm \
-      ${extrapkg}/centos-release-gluster312-1.0-1.el7.centos.noarch.rpm \
+      ${extrapkg}/centos-release-storage-common-2-2.el7.centos.noarch.rpm \
+      ${extrapkg}/centos-release-gluster41-1.0-3.el7.centos.noarch.rpm \
       "; \
   else \
-    PRE_INSTALL_PKG="${PRE_INSTALL_PKG} centos-release-gluster312"; \
+    PRE_INSTALL_PKG="${PRE_INSTALL_PKG} centos-release-gluster41"; \
   fi && \
   yum install -y --setopt=tsflags=nodocs $PRE_INSTALL_PKG && \
   INSTALL_PKGS="bash tar jq findutils which glusterfs-fuse" && \


### PR DESCRIPTION
Gluster 3.12 has been end-of-life-ed with the release of Gluster 5.0 on
October 23, 2018.