### PR TITLE
Re-add support for OpenShift 3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ finds on the volumes which it is recycling.
 
 ## Requirements
 
-* OpenShift Container Platform 3.9 or later
-* OpenShift Origin 3.9 or later
+* OpenShift Container Platform 3.7 or later
+* OpenShift Origin 3.7 or later
 
 
 ## Role Variables

--- a/files/recycler-template.yml
+++ b/files/recycler-template.yml
@@ -90,7 +90,7 @@ objects:
   userNames:
   - system:serviceaccount:${NAMESPACE}:gluster-recycler
 
-- apiVersion: batch/v1beta1
+- apiVersion: batch/v2alpha1
   kind: CronJob
   metadata:
     name: gluster-recycler
@@ -148,8 +148,10 @@ objects:
                   mountPath: /recycler-secrets
                   readOnly: true
             serviceAccountName: gluster-recycler
+            # TODO: Switch to "Never" once OpenShift 3.7 doesn't need to be
+            # supported anymore
             # https://github.com/kubernetes/kubernetes/issues/54870
-            restartPolicy: Never
+            restartPolicy: OnFailure
             nodeSelector: ${{NODE_SELECTOR_JSON}}
             volumes:
               - name: secrets


### PR DESCRIPTION
There are still clusters running OpenShift 3.7. The "batch/v1beta1" api
version isn't known on those and the pod restart policy must be
configured as "OnFailure" (see
<https://github.com/kubernetes/kubernetes/issues/54870>).