### PR TITLE
Reduce history limits from 10 to 3

### DIFF
--- a/files/recycler-cronjob-v3.7.yml
+++ b/files/recycler-cronjob-v3.7.yml
@@ -56,8 +56,8 @@ objects:
         }]
   spec:
     schedule: ${SCHEDULE}
-    failedJobsHistoryLimit: 10
-    successfulJobsHistoryLimit: 10
+    failedJobsHistoryLimit: 3
+    successfulJobsHistoryLimit: 3
     concurrencyPolicy: Forbid
     startingDeadlineSeconds: 86400
     jobTemplate:

--- a/files/recycler-cronjob.yml
+++ b/files/recycler-cronjob.yml
@@ -56,8 +56,8 @@ objects:
         }]
   spec:
     schedule: ${SCHEDULE}
-    failedJobsHistoryLimit: 10
-    successfulJobsHistoryLimit: 10
+    failedJobsHistoryLimit: 3
+    successfulJobsHistoryLimit: 3
     concurrencyPolicy: Forbid
     startingDeadlineSeconds: 86400
     jobTemplate:


### PR DESCRIPTION
On most clusters logs are collected by OpenShift's logging component.
There's no need to keep as many pods around.