### PR TITLE
Exclude Gluster trashcan from removal

### DIFF
--- a/recycler.sh
+++ b/recycler.sh
@@ -194,7 +194,7 @@ clear_volume() {
   fi
 
   # delete all the files with -mindepth 1 so we don't try and remove the mount directory
-  if ! timeout "${TIMEOUT_DELETE}s" find "$path" -mindepth 1 -not -path "${path}/.trashcan/*" -delete; then
+  if ! timeout "${TIMEOUT_DELETE}s" find "$path" -mindepth 1 -not \( -path "${path}/.trashcan" -or -path "${path}/.trashcan/*" \) -delete; then
     echo "Removing volume content failed (timeout ${TIMEOUT_DELETE}s)"
     return 1
   fi


### PR DESCRIPTION
Commit c541a57 added a slash to the path filter excluding the Gluster
trashcan. What it didn't consider is that the directory itself can't be
removed either even though it's no longer matched:

  find: cannot delete '/mnt/…/.trashcan': Directory not empty

This change amends the condition to exclude both "…/.trashcan" (the
directory) and "…/.trashcan/*" (everything inside).