### PR TITLE
Avoid clearing "gluster-recycler" secret

### DIFF
--- a/files/recycler-template.yml
+++ b/files/recycler-template.yml
@@ -68,7 +68,6 @@ objects:
   kind: Secret
   metadata:
     name: gluster-recycler
-  data: {}
 
 - apiVersion: v1
   kind: ClusterRoleBinding


### PR DESCRIPTION
When re-deploying the template would replace all keys defined in the
secret for the recycler. Considering that TLS client key, certificate
and authorities need to be configured by another process that's
undesirable.