### PR TITLE
Reset SELinux context upon recycling

### DIFF
--- a/recycler.sh
+++ b/recycler.sh
@@ -214,6 +214,12 @@ clear_volume() {
     return 1
   fi
 
+  # reset SELinux context
+  if ! chcon 'system_u:object_r:unlabeled_t:s0' "$path"; then
+    echo Resetting SELinux context failed
+    return 1
+  fi
+
   return 0
 }
 


### PR DESCRIPTION
In theory it is possible for privileged pods to change the selinux context of the root directory. This commits enforces the expected default context upon recycling.