### PR TITLE
Revert "Reset SELinux context upon recycling"

### DIFF
--- a/recycler.sh
+++ b/recycler.sh
@@ -214,12 +214,6 @@ clear_volume() {
     return 1
   fi
 
-  # reset SELinux context
-  if ! chcon 'system_u:object_r:unlabeled_t:s0' "$path"; then
-    echo Resetting SELinux context failed
-    return 1
-  fi
-
   return 0
 }
 


### PR DESCRIPTION
The FUSE Gluster client does not support SELinux operations [1], therefore
the SELinux context of a volume cannot be modified while the volume is
in use and does not need to be reset during volume recycling.

This reverts commit 64401aacc911c8f6c889708e3f29049013aeadb2.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1230671